### PR TITLE
Darksky API service

### DIFF
--- a/api/external_services/darksky_service.py
+++ b/api/external_services/darksky_service.py
@@ -4,9 +4,9 @@ from django.conf import settings
 class DarkskyService:
 
     def get_json(self, uri):
-        response = requests.get(f' https://api.darksky.net/forecast/{settings.DARKSKY_API_KEY}/{uri}')
+        response = requests.get(f'https://api.darksky.net/forecast/{settings.DARKSKY_API_KEY}/{uri}')
         return response.json()
 
     def get_forecast(self, lat, lng, time):
-        uri = f'{lat},{lng},{time}'
+        uri = f'{lat},{lng},{time}?exclude=hourly,daily,alerts,flags'
         return self.get_json(uri)

--- a/api/external_services/darksky_service.py
+++ b/api/external_services/darksky_service.py
@@ -1,0 +1,12 @@
+import requests
+from django.conf import settings
+
+class DarkskyService:
+
+    def get_json(self, uri):
+        response = requests.get(f' https://api.darksky.net/forecast/{settings.DARKSKY_API_KEY}/{uri}')
+        return response.json()
+
+    def get_forecast(self, lat, lng, time):
+        uri = f'{lat},{lng},{time}'
+        return self.get_json(uri)

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,34 @@
 from django.test import TestCase
-
+from api.external_services.darksky_service import DarkskyService
 # Create your tests here.
+
+class DarkskyServiceTestCase(TestCase):
+    def test_service_returns_json_of_forecast(self):
+        expected_response = {
+                                "latitude": 39.742043,
+                                "longitude": -104.991531,
+                                "timezone": "America/Denver",
+                                "currently": {
+                                    "time": 255657600,
+                                    "summary": "Overcast",
+                                    "icon": "cloudy",
+                                    "precipIntensity": 0,
+                                    "precipProbability": 0,
+                                    "temperature": 36.84,
+                                    "apparentTemperature": 28.68,
+                                    "dewPoint": 26.83,
+                                    "humidity": 0.67,
+                                    "pressure": 1005.5,
+                                    "windSpeed": 12.47,
+                                    "windBearing": 8,
+                                    "cloudCover": 1,
+                                    "uvIndex": 0,
+                                    "visibility": 9.997
+                                },
+                                "offset": -7
+                            }
+
+
+        service = DarkskyService()
+        response = service.get_forecast('39.742043','-104.991531','255657600')
+        self.assertEqual(response, expected_response)

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from api.external_services.darksky_service import DarkskyService
+from api.external_services.geocode_service import GeocodeService
 # Create your tests here.
 
 class DarkskyServiceTestCase(TestCase):
@@ -31,4 +32,16 @@ class DarkskyServiceTestCase(TestCase):
 
         service = DarkskyService()
         response = service.get_forecast('39.742043','-104.991531','255657600')
+        self.assertEqual(response, expected_response)
+
+
+class GeocodeServiceTestCase(TestCase):
+    def test_service_returns_hash_of_latitude_and_longitude_for_location(self):
+        expected_response = {
+                            "lat": 39.7392358,
+                            "lng": -104.990251
+                            }
+
+        service = GeocodeService()
+        response = service.get_coordinates('denver,co')
         self.assertEqual(response, expected_response)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Chore
- [ ] Documentation Update

## Description
Created `DarkskyService` class to handle API calls to the Darksky Weather API. The `get_forecast` function takes three arguments: lat, lng, and time. Time will need to be formatted as a time integer (?) in order for Darksky API call to send a valid request.

Also added two tests to our `tests.py` file to test the expected responses from both the DarkskyService.get_forecast function and GeocodeService.get_coordinates function.

## Related Issues & Documents
Closes #4 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Be sure to add your personal Darksky API key to your `local_settings.py` file as the service calls this variable in order to make the request.
