### PR TITLE
Index user scheduled activities endpoint and add queries to return primary and secondary relationships for activities and musclegroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,302 +95,183 @@
 ```
 {
     "id": 1,
-    "date": "2020-04-06T03:23:24Z",
-    "location": "Denver, CO",
-    "forecast": "Overcast",
-    "forecast_img": "cloudy",
-    "activity": {
-        "id": 1,
-        "name": "Hiking",
-        "muscle_groups": [
-            "primary": [
-              {
-                  "id": 1,
-                  "name": "Biceps",
-                  "exercise_set": [
-                      {
-                          "id": 1,
-                          "name": "Pull Ups",
-                          "description": "Pull yourself up",
-                          "img_url": "fake_img"
-                      }
-                  ]
-              }
-            ],
-            "secondary": [
-              {
-                  "id": 2,
-                  "name": "Forearms",
-                  "exercise_set": [
-                      {
-                          "id": 3,
-                          "name": "Push Ups",
-                          "description": "Push yo' self",
-                          "img_url": "some_img"
-                      },
-                      {
-                          "id": 4,
-                          "name": "Small Arm Circles",
-                          "description": "Feel the burn",
-                          "img_url": "some_img"
-                      },
-                  ]
-              }
-            ]
-        ]
-    },
-    "user": {
-        "id": 1,
-        "first_name": "user",
-        "last_name": "name"
-    },
-    "created_at": "2020-04-06T03:23:26.122544Z",
-    "updated_at": "2020-04-06T03:23:26.122555Z"
-}, {
-    "id": 2,
-    "date": "2020-04-01T03:23:24Z",
-    "location": "Las Vegas, Nv",
-    "forecast": "Sunny",
-    "forecast_img": "sunshine",
-    "activity": {
-        "id": 3,
-        "name": "Running",
-        "muscle_groups": [
-            {
-                "id": 4,
-                "name": "Calves",
-                "exercise_set": [
-                    {
-                        "id": 1,
-                        "name": "Pull Ups",
-                        "description": "Pull yourself up ya dingus",
-                        "img_url": "fake_img"
-                    },
-                    {
-                        "id": 2,
-                        "name": "Curls",
-                        "description": "curl some heavy weights",
-                        "img_url": "some_img"
-                    },
-                    {
-                        "id": 3,
-                        "name": "Push Ups",
-                        "description": "Push yo' self",
-                        "img_url": "some_img"
-                    },
-                    {
-                        "id": 4,
-                        "name": "Small Arm Circles",
-                        "description": "Feel the burn",
-                        "img_url": "some_img"
-                    },
-                    {
-                        "id": 5,
-                        "name": "Big Arm Circles",
-                        "description": "Feel the bigger burn",
-                        "img_url": "some_img"
-                    },
-                    {
-                        "id": 6,
-                        "name": "Jumping Jacks",
-                        "description": "Don't stop, get it, get it",
-                        "img_url": "some_img"
-                    },
-                ]
-            }
-        ]
-    },
-    "user": {
-        "id": 1,
-        "first_name": "user",
-        "last_name": "name"
-    },
-    "created_at": "2020-04-02T03:23:26.122544Z",
-    "updated_at": "2020-04-02T03:23:26.122555Z"
-}, {
-    "id": 3,
-    "date": "2020-04-02T03:23:24Z",
-    "location": "Boulder, CO",
-    "forecast": "Rainyt",
-    "forecast_img": "rainclouds",
-    "activity": {
-        "id": 4,
-        "name": "Kayaking",
-        "muscle_groups": [
-            {
-                "id": 1,
-                "name": "Biceps",
-                "exercise_set": [
-                    {
-                        "id": 3,
-                        "name": "Push Ups",
-                        "description": "Push yo' self",
-                        "img_url": "some_img"
-                    },
-                    {
-                        "id": 1,
-                        "name": "Pull Ups",
-                        "description": "Pull yourself up ya dingus",
-                        "img_url": "fake_img"
-                    }
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Ankles",
-                "exercise_set": [
-                    {
-                        "id": 2,
-                        "name": "Curls",
-                        "description": "curl some heavy weights",
-                        "img_url": "some_img"
-                    }
-                ]
-            }
-        ]
-    },
-    "user": {
-        "id": 1,
-        "first_name": "user",
-        "last_name": "name"
-    },
-    "created_at": "2020-04-08T03:23:26.122544Z",
-    "updated_at": "2020-04-08T03:23:26.122555Z"
-},  {
-    "id": 4,
-    "date": "2020-04-07T03:23:24Z",
-    "location": "Denver, CO",
-    "forecast": "Windy",
-    "forecast_img": "a picture of wind",
-    "activity": {
-        "id": 4,
-        "name": "Kayaking",
-        "muscle_groups": [
-            {
-                "id": 1,
-                "name": "Biceps",
-                "exercise_set": [
-                    {
-                        "id": 3,
-                        "name": "Push Ups",
-                        "description": "Push yo' self",
-                        "img_url": "some_img"
-                    },
-                    {
-                        "id": 1,
-                        "name": "Pull Ups",
-                        "description": "Pull yourself up ya dingus",
-                        "img_url": "fake_img"
-                    }
-                ]
-            },
-            {
-                "id": 3,
-                "name": "Ankles",
-                "exercise_set": [
-                    {
-                        "id": 2,
-                        "name": "Curls",
-                        "description": "curl some heavy weights",
-                        "img_url": "some_img"
-                    }
-                ]
-            }
-        ]
-    },
-    "user": {
-        "id": 1,
-        "first_name": "user",
-        "last_name": "name"
-    },
-    "created_at": "2020-04-06T03:23:26.122544Z",
-    "updated_at": "2020-04-06T03:23:26.122555Z"
-} {
-    "id": 2,
-    "date": "2020-04-07T03:23:24Z",
+    "date": "2020-04-07T20:42:24Z",
     "location": "Denver, CO",
     "forecast": "Sunny",
     "forecast_img": "sunshine",
     "activity": {
-        "id": 2,
-        "name": "Biking",
-        "muscle_groups": [
+        "id": 1,
+        "name": "Mountain Biking",
+        "primary_muscles": [
             {
-                "id": 4,
-                "name": "Calves",
-                "exercise_set": [
+                "id": 11,
+                "name": "Obliques",
+                "primary_exercises": [
                     {
-                        "id": 1,
-                        "name": "Pull Ups",
-                        "description": "Pull yourself up ya dingus",
-                        "img_url": "fake_img"
+                        "id": 25,
+                        "name": "bench-swiss-exercise-ball-russian-twists",
+                        "description": "Targets abs and obliques.",
+                        "img_url": "",
+                        "equipment": "Swiss / Exercise ball",
+                        "instructions": "Straddle a bench and hold a Swiss ball comfortably on your lap. Using your legs to hold the bench, lean your body back until your abdominal muscles are working to keep you upright (aim for a 45 degree angle) . Extend your arms to hold the Swiss ball directly out in front of your chest.   Rotate your body to the left holding the Swiss ball at the extended position. Rotate your body back to the center and then to the right to complete 1 full repetition.  "
                     },
                     {
-                        "id": 2,
-                        "name": "Curls",
-                        "description": "curl some heavy weights",
-                        "img_url": "some_img"
+                        "id": 38,
+                        "name": "bosu-ball-side-planks",
+                        "description": "Targets abs and obliques and also involves shoulders.",
+                        "img_url": "",
+                        "equipment": "Bosu ball",
+                        "instructions": "With a Bosu ball round side up, place your forearm onto the center of the ball.  Stretch out your legs to a fully extended position and place your feet on the side, one on top of the other.  Use you core and upper legs to lift your body into the side plank position. Remain in this position for the designated time with your hand either on your hip, or by your side."
                     },
+                    {
+                        "id": 61,
+                        "name": "crab-walks",
+                        "description": "Targets glutes & hip flexors and shoulders and also involves abs.",
+                        "img_url": "",
+                        "equipment": "NO EQUIPMENT",
+                        "instructions": "Sit on the ground with your knees bent, feet flat on the ground and your hands behind you. Your hands should be facing forward towards you. Begin the movement by lifting your hips into the air and bracing your abdominals. Your hips must stay up throughout the movement. Walk forward by moving your right foot and right hand forward. Switch to the left side. Continue this back and forth pattern while keeping your hips elevated. When finished, lower yourself to the ground."
+                    },
+                    {
+                        "id": 69,
+                        "name": "double-crunches",
+                        "description": "Targets abs.",
+                        "img_url": "",
+                        "equipment": "NO EQUIPMENT",
+                        "instructions": "Lie on your back. Bring your knees up to a 90-degree angle. Shins should be parallel to the floor. Place your hands behind your head and bring your shoulders off the ground. Exhale and contract your abdominals. Bring your head towards your knees while moving your knees toward your chest. Pause and return to the starting position."
+                    },
+                    {
+                        "id": 73,
+                        "name": "dumbbell-biceps-curl-to-shoulder-press",
+                        "description": "Targets biceps and shoulders and also involves abs.",
+                        "img_url": "",
+                        "equipment": "Dumbbells",
+                        "instructions": "Holding a pair of dumbbells, stand tall with your feet shoulder-width apart. Make sure your core is tight and your chest is up. Begin by curling the weight up towards your shoulders. Keep your upper arms tight at your sides. Once the dumbbells reach your shoulders, twist the dumbbells to have your palms face out. Now, drive the dumbbells overhead. Slowly, lower the dumbbells to your shoulders. Now, flip them back so your palms are facing you. With arms tight at your sides, lower the dumbbells to the starting position."
+                    }
+                ]
+            }
+        ],
+        "secondary_muscles": [
+            {
+                "id": 13,
+                "name": "Shoulders",
+                "secondary_exercises": [
                     {
                         "id": 3,
-                        "name": "Push Ups",
-                        "description": "Push yo' self",
-                        "img_url": "some_img"
+                        "name": "agility-ladder-drills",
+                        "description": "Targets abs and calves and glutes & hip flexors and hamstrings and lower back and quadriceps and also involves biceps and shoulders and triceps.",
+                        "img_url": "",
+                        "equipment": "Agility Ladder",
+                        "instructions": "Lay out the agility ladder on a non-slip surface.  Perform a routine of choice."
                     },
                     {
-                        "id": 4,
-                        "name": "Small Arm Circles",
-                        "description": "Feel the burn",
-                        "img_url": "some_img"
+                        "id": 12,
+                        "name": "barbell-overhead-squats",
+                        "description": "Targets calves and hamstrings and quadriceps and also involves abs and shoulders.",
+                        "img_url": "",
+                        "equipment": "Barbell / EZ-Bar",
+                        "instructions": "Place an appropriate amount of weight on a barbell in a squat rack. Position your hands in an overhand grip outside of shoulder-width on the barbell. Before beginning, make sure that your core is tight and your chest is up. Push the barbell straight above your head, locking out your elbows. Once you feel stabilized, slowly bend the knees and drive back your hips. Once your upper thighs come parallel with the ground, slowly push back up, returning to the starting position."
                     },
                     {
-                        "id": 5,
-                        "name": "Big Arm Circles",
-                        "description": "Feel the bigger burn",
-                        "img_url": "some_img"
+                        "id": 13,
+                        "name": "barbell-pushups-push-ups",
+                        "description": "Targets chest and triceps and also involves abs and shoulders.",
+                        "img_url": "",
+                        "equipment": "Barbell / EZ-Bar",
+                        "instructions": "Place a loaded barbell on the floor and place your hands at a slightly-wider-than-shoulder-width grip.  Bracing your core, get into push-up position with a straight posture from head to heel. Lower your body down until your chest hovers about ½ an inch from the bar. Use a combination of chest and triceps power to push your body back up away from the bar."
                     },
                     {
-                        "id": 6,
-                        "name": "Jumping Jacks",
-                        "description": "Don't stop, get it, get it",
-                        "img_url": "some_img"
+                        "id": 29,
+                        "name": "bent-over-water-bottle-flyes",
+                        "description": "Targets upper back & lower traps and also involves shoulders.",
+                        "img_url": "",
+                        "equipment": "Water Bottles",
+                        "instructions": "Begin by holding a pair of water bottles and standing with a braced core. Bend at the knees slightly and lean forward from the hips. Maintain a flat back throughout. Keeping your elbows slightly bent throughout the movement, lift the water bottles up and out to the side. Be sure to focus the contraction in the back of the shoulders. Pause at the top of the movement then slowly bring the water bottles to the starting position."
                     },
+                    {
+                        "id": 36,
+                        "name": "bosu-ball-chest-dumbbell-flyes-flies",
+                        "description": "Targets abs and chest and also involves shoulders and triceps.",
+                        "img_url": "",
+                        "equipment": "Bosu ball, Dumbbells",
+                        "instructions": "Begin by sitting on the floor with your lower back against the side of the Bosu ball, and with the dumbbells resting on your upper thighs.  Lower yourself back onto the Bosu ball while bringing the dumbbells onto your chest. Naturally you should create a straight bridge from your knees to your shoulders. Extend the dumbbells upward so that they are directly above your chest, without locking your arms, while keeping you hands internally rotated. Lower the the dumbbells away from each other, opening your chest while creating tension. Be sure not to lower the dumbbells past your shoulder line.   Bring the dumbbells back inwards to meet in the central starting position. Like hugging a barrel."
+                    }
                 ]
             },
             {
-                "id": 5,
-                "name": "Knees",
-                "exercise_set": [
+                "id": 9,
+                "name": "Middle Back / Lats",
+                "secondary_exercises": [
                     {
-                        "id": 1,
-                        "name": "Pull Ups",
-                        "description": "Pull yourself up ya dingus",
-                        "img_url": "fake_img"
+                        "id": 111,
+                        "name": "gymnastic-ring-pull-ups-pullups",
+                        "description": "Targets middle back / lats and upper back & lower traps and also involves biceps and forearms and shoulders.",
+                        "img_url": "",
+                        "equipment": "Gymnastic Rings",
+                        "instructions": "Stand directly beneath the Gymnastic Rings ensuring that they have enough height for you to lower your body without touching the ground.  Grip the rings so that your palms are facing inward. Pull your chest upwards and towards the rings by bending your arms. Aim to avoid any jerking movements as this may cause the rings to swing.  Once your chest is at its highest point, hold this position for one second before steadily lowering your body back down to the starting position."
                     },
                     {
-                        "id": 3,
-                        "name": "Push Ups",
-                        "description": "Push yo' self",
-                        "img_url": "some_img"
+                        "id": 115,
+                        "name": "hamstring-stretch",
+                        "description": "Targets hamstrings and also involves glutes & hip flexors.",
+                        "img_url": "",
+                        "equipment": "NO EQUIPMENT",
+                        "instructions": "Sit on a mat and extend your right leg out to the side. Bend your left leg and place the foot against your inner right thigh. Lean forward from the hips and reach for your ankle as comfortably as you can. You should feel a slight pull in the hamstring. Hold the stretch and then repeat on the left leg."
                     },
                     {
-                        "id": 4,
-                        "name": "Small Arm Circles",
-                        "description": "Feel the burn",
-                        "img_url": "some_img"
+                        "id": 118,
+                        "name": "hanging-leg-raises",
+                        "description": "Targets abs and also involves forearms and glutes & hip flexors.",
+                        "img_url": "",
+                        "equipment": "Full gym, NO EQUIPMENT",
+                        "instructions": "Grip a chin up or pull up bar with a firm overhand grip. Hang from the bar with your legs straight. Raise your legs by flexing your hips forward and bending your knees up towards your chest. Continue to raise your knees towards your chest by flexing your waist forward. Don’t swing your body to use momentum. Use your abdominals to pull your legs up. Return to the starting position, lowering your legs slowly until they are straight. Repeat."
                     },
+                    {
+                        "id": 119,
+                        "name": "hanging-leg-raises-to-bar",
+                        "description": "Targets abs and obliques and also involves middle back / lats.",
+                        "img_url": "",
+                        "equipment": "Full gym",
+                        "instructions": "Assume a wide grip on a pull-up bar and hang so that your feet are not in contact with the ground.  Once steady, slowly lift your knees up towards your chest, doing your best to keep your legs fully extended.  Allow you upper back to drop backward to create balance and avoid swinging as your legs continue to rise. Bring your toes up to touch the bar before slowly lowering them back down to the starting, hanging position."
+                    },
+                    {
+                        "id": 132,
+                        "name": "jump-squats",
+                        "description": "Targets glutes & hip flexors and quadriceps and also involves abs and calves and hamstrings.",
+                        "img_url": "",
+                        "equipment": "NO EQUIPMENT",
+                        "instructions": "Stand with your feet hip width apart. Your toes should be pointing straight ahead or only slightly outward. Cross your arms in front of your body, place your hands behind your head or at the sides of your head. Keep your weight on your heels and bend your knees while lowering your hips towards the ground as if you are sitting down on a chair. Keep your back straight at all times. Continue until you feel a slight stretch in your quadriceps. Do not let your knees extend out beyond the level of your toes. Pause for a count of one. In an explosive movement, drive down through your heels pushing yourself up of the floor with your quads. At the same time extend our arms out above you. Land with your knees slightly bent to absorb the impact. Repeat"
+                    }
                 ]
             }
         ]
     },
     "user": {
         "id": 1,
+        "username": "user",
         "first_name": "user",
-        "last_name": "name"
+        "last_name": "name",
+        "scheduled_activities": [
+            {
+                "id": 1,
+                "activity": "Mountain Biking",
+                "date": "2020-04-07T20:42:24Z",
+                "location": "Denver, CO",
+                "forecast": "Sunny",
+                "forecast_img": "sunshine"
+            },
+            {
+                "id": 2,
+                "activity": "Frisbee",
+                "date": "2020-04-09T22:37:44Z",
+                "location": "Breckenridge, CO",
+                "forecast": "Overcast",
+                "forecast_img": "cloudy"
+            }
+        ]
     },
-    "created_at": "2020-04-03T03:23:26.122544Z",
-    "updated_at": "2020-04-03T03:23:26.122555Z"
-},
+    "created_at": "2020-04-07T20:43:07.198918Z",
+    "updated_at": "2020-04-07T20:43:07.198936Z"
+}
 ```
 
 - GET `/api/v1/:user_id/scheduled_activities`

--- a/api/models.py
+++ b/api/models.py
@@ -27,13 +27,6 @@ class Exercise(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     equipment = models.CharField(max_length=2000)
     instructions = models.CharField(max_length=2000)
-    
-    # def primary_muscles(self):
-    #     return ['biceps', 'triceps']
-    #     return self.objects.filter(MuscleGroup__name='Abs')
-    #
-    # def secondary_muscles(self):
-    #     return ['quadriceps', 'calves']
 
 
 class User(models.Model):

--- a/api/models.py
+++ b/api/models.py
@@ -14,6 +14,9 @@ class Activity(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    def __str__(self):
+        return self.name
+
 
 class Exercise(models.Model):
     name = models.CharField(max_length=255)
@@ -24,7 +27,7 @@ class Exercise(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     equipment = models.CharField(max_length=2000)
     instructions = models.CharField(max_length=2000)
-
+    
     # def primary_muscles(self):
     #     return ['biceps', 'triceps']
     #     return self.objects.filter(MuscleGroup__name='Abs')
@@ -41,6 +44,9 @@ class User(models.Model):
     email = models.CharField(max_length=255)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    def scheduled_activities(self):
+        return ScheduledActivity.objects.filter(user=self.id)
 
 
 class ScheduledActivity(models.Model):

--- a/api/models.py
+++ b/api/models.py
@@ -7,6 +7,11 @@ class MuscleGroup(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    def primary_exercises(self):
+        return Exercise.objects.raw(f"SELECT * FROM api_exercise JOIN api_exercisemusclegroups ON api_exercise.id = api_exercisemusclegroups.exercise_id WHERE api_exercisemusclegroups.muscle_group_id = {self.id} AND api_exercisemusclegroups.type = 'primary' LIMIT 5")
+
+    def secondary_exercises(self):
+        return Exercise.objects.raw(f"SELECT * FROM api_exercise JOIN api_exercisemusclegroups ON api_exercise.id = api_exercisemusclegroups.exercise_id WHERE api_exercisemusclegroups.muscle_group_id = {self.id} AND api_exercisemusclegroups.type = 'secondary' LIMIT 5")
 
 class Activity(models.Model):
     name = models.CharField(max_length=255)
@@ -16,6 +21,12 @@ class Activity(models.Model):
 
     def __str__(self):
         return self.name
+
+    def primary_muscles(self):
+        return MuscleGroup.objects.raw(f"SELECT * FROM api_musclegroup JOIN api_activitymusclegroups ON api_activitymusclegroups.muscle_group_id = api_musclegroup.id WHERE api_activitymusclegroups.activity_id = {self.id} AND api_activitymusclegroups.type = 'primary'")
+
+    def secondary_muscles(self):
+        return MuscleGroup.objects.raw(f"SELECT * FROM api_musclegroup JOIN api_activitymusclegroups ON api_activitymusclegroups.muscle_group_id = api_musclegroup.id WHERE api_activitymusclegroups.activity_id = {self.id} AND api_activitymusclegroups.type = 'secondary'")
 
 
 class Exercise(models.Model):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -22,10 +22,18 @@ class ActivitySerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'muscle_groups']
 
 
+class ScheduledActivityIndexSerializer(serializers.ModelSerializer):
+    activity = serializers.StringRelatedField()
+    class Meta:
+        model = ScheduledActivity
+        fields = ['id', 'activity', 'date', 'location', 'forecast', 'forecast_img']
+
+
 class UserSerializer(serializers.ModelSerializer):
+    scheduled_activities = ScheduledActivityIndexSerializer(many=True)
     class Meta:
         model = User
-        fields = ['id', 'first_name', 'last_name']
+        fields = ['id', 'username', 'first_name', 'last_name', 'scheduled_activities']
 
 
 class ScheduledActivitySerializer(serializers.ModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -15,11 +15,27 @@ class MuscleGroupSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'exercise_set']
 
 
+class PrimaryMuscleGroupSerializer(serializers.ModelSerializer):
+    primary_exercises = ActivityExerciseSerializer(many=True)
+    class Meta:
+        model = MuscleGroup
+        fields = ['id', 'name', 'primary_exercises']
+
+
+class SecondaryMuscleGroupSerializer(serializers.ModelSerializer):
+    secondary_exercises = ActivityExerciseSerializer(many=True)
+    class Meta:
+        model = MuscleGroup
+        fields = ['id', 'name', 'secondary_exercises']
+
+
 class ActivitySerializer(serializers.ModelSerializer):
-    muscle_groups = MuscleGroupSerializer(many=True)
+    # muscle_groups = MuscleGroupSerializer(many=True)
+    primary_muscles = PrimaryMuscleGroupSerializer(many=True)
+    secondary_muscles = SecondaryMuscleGroupSerializer(many=True)
     class Meta:
         model = Activity
-        fields = ['id', 'name', 'muscle_groups']
+        fields = ['id', 'name', 'primary_muscles', 'secondary_muscles']
 
 
 class ScheduledActivityIndexSerializer(serializers.ModelSerializer):

--- a/api/urls.py
+++ b/api/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('exercises', views.exercise_index, name="exercise_index"),
     path('exercises/<int:exercise_id>', views.exercise_show),
     path('scheduled_activities/<int:scheduled_activity_id>', views.scheduled_activity_show),
-    path('activities', views.activity_index)
+    path('activities', views.activity_index),
+    path('<int:user_id>/scheduled_activities', views.user_scheduled_activity_index),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -27,3 +27,10 @@ def scheduled_activity_show(request, scheduled_activity_id):
     queryset = ScheduledActivity.objects.get(id=scheduled_activity_id)
     serializer = ScheduledActivitySerializer(queryset)
     return JsonResponse(serializer.data)
+
+
+def user_scheduled_activity_index(request, user_id):
+    queryset = User.objects.get(id=user_id)
+    # import pdb; pdb.set_trace()
+    serializer = UserSerializer(queryset)
+    return JsonResponse(serializer.data)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Chore
- [ ] Documentation Update

## Description
- Create endpoint to return a list of a user's scheduled activities at 'api/v1/:user_id/scheduled_activities'

- Refactor JSON output for a specific scheduled activity:
1) Add `primary_exercises()` and `secondary_muscles` methods to `MuscleGroup` model.

    `primary_exercises()` - returns collection of Exercise objects that have that muscle listed as 
     "primary" `type` on the joins table. Querey limits return to 5 objects.

     `secondary_exercises()` - returns collection of Exercise objects that have that muscle listed 
      as "secondary" `type` on the joins table. Query limits return to 5 objects.

2) Add `primary_muscles()` and `secondary_muscles()` methods to `Activity` model.

     `primary_muscles()` - returns a collection of MuscleGroup objects that are that activity's 
      'primary' muscles.

      `secondary_muscles()` - returns collection of MuscleGroup objects that are listed as 
      'secondary' muscles for that activity.

## Related Issues & Documents
Closes #11 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help

## Added to documentation?

- [x] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
