### PR TITLE
Update create_scheduled_activity to find Activity based off name. Upd…

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -96,7 +96,7 @@ class NewScheduledActivity(TestCase):
         user = User.objects.create(username="test_user", first_name="Test", last_name="Name", email="test@example.com")
 
         c = Client()
-        response = c.post(f'/api/v1/users/{user.id}/scheduled_activities/new', {"activity_id": f"{activity.id}", "date": "2020-04-20", "location": "Golden, CO"})
+        response = c.post(f'/api/v1/users/{user.id}/scheduled_activities/new', {"activity_name": f"{activity.name}", "date": "2020-04-20", "location": "Golden, CO"})
 
         self.assertEqual(200, response.status_code)
 

--- a/api/views.py
+++ b/api/views.py
@@ -43,7 +43,7 @@ def user_scheduled_activity_index(request, user_id):
 
 @api_view(['POST'])
 def create_scheduled_activity(request, user_id):
-    activity = Activity.objects.get(id=request.data["activity_id"])
+    activity = Activity.objects.get(name=request.data["activity_name"])
     date = parse_date(request.data["date"])
     location = request.data["location"]
     user = User.objects.get(id=user_id)


### PR DESCRIPTION
…ate test to pass name in body of request

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Chore
- [ ] Documentation Update

## Description

Front end is passing `activity_name` in body of request now so need to revert changes back to finding Activity based off `name`.

## Related Issues & Documents

Closes #41 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
