### PR TITLE
Delete scheduled activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,11 @@
     ]
 }
 ```
+
+- DELETE `/api/v1/users/:user_id/scheduled_activities/:scheduled_activity_id`
+
+If request is successful, will return `204` status and `Deleted successfully` message.
+
+If record cannot be found based off the ID provided in the URL, will return `404` and `Record not found` message.
+
+If server runs into an error when trying to delete a record, will raise `500` error and `Unable to delete record` message.

--- a/api/tests.py
+++ b/api/tests.py
@@ -134,3 +134,65 @@ class NewScheduledActivity(TestCase):
         scheduled_activity.save()
 
         self.assertEqual("good", scheduled_activity.status)
+
+    def test_it_can_be_deleted(self):
+        activity = Activity.objects.create(name="Kayaking")
+
+        user = User.objects.create(username="test_user", first_name="Test", last_name="Name", email="test@example.com")
+
+        scheduled_activity_1 = ScheduledActivity.objects.create(
+            date="2020-04-15",
+            location="Denver, CO",
+            forecast="Sunny",
+            forecast_img="sunny",
+            temperature=45.20,
+            temp_hi=60.00,
+            temp_low=23.00,
+            precip_probability=0.07,
+            activity=activity,
+            user=user
+            )
+
+        scheduled_activity_2 = ScheduledActivity.objects.create(
+            date="2020-04-19",
+            location="Fort Collins, CO",
+            forecast="Sunny",
+            forecast_img="sunny",
+            temperature=45.20,
+            temp_hi=60.00,
+            temp_low=23.00,
+            precip_probability=0.07,
+            activity=activity,
+            user=user
+            )
+
+        c = Client()
+
+        response = c.delete(f'/api/v1/users/{user.id}/scheduled_activities/{scheduled_activity_1.id}')
+
+        self.assertEqual(204, response.status_code)
+        self.assertEqual(scheduled_activity_2, ScheduledActivity.objects.all()[0])
+
+    def test_bad_delete_request_returns_404(self):
+        activity = Activity.objects.create(name="Kayaking")
+
+        user = User.objects.create(username="test_user", first_name="Test", last_name="Name", email="test@example.com")
+
+        scheduled_activity_1 = ScheduledActivity.objects.create(
+            date="2020-04-15",
+            location="Denver, CO",
+            forecast="Sunny",
+            forecast_img="sunny",
+            temperature=45.20,
+            temp_hi=60.00,
+            temp_low=23.00,
+            precip_probability=0.07,
+            activity=activity,
+            user=user
+            )
+
+        c = Client()
+
+        response = c.delete(f'/api/v1/users/{user.id}/scheduled_activities/5')
+
+        self.assertEqual(404, response.status_code)

--- a/api/urls.py
+++ b/api/urls.py
@@ -5,7 +5,7 @@ from . import views
 urlpatterns = [
     path('exercises', views.exercise_index, name="exercise_index"),
     path('exercises/<int:exercise_id>', views.exercise_show),
-    path('users/<int:user_id>/scheduled_activities/<int:scheduled_activity_id>', views.scheduled_activity_show),
+    path('users/<int:user_id>/scheduled_activities/<int:scheduled_activity_id>', views.scheduled_activity),
     path('activities', views.activity_index),
     path('users/<int:user_id>/scheduled_activities', views.user_scheduled_activity_index),
     path('users/<int:user_id>/scheduled_activities/new', views.create_scheduled_activity),

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, HttpResponse
 from django.http import JsonResponse
 from api.models import *
 from api.serializers import *
@@ -29,12 +29,28 @@ def activity_index(request):
     serializer = ActivityIndexSerializer(queryset, many=True)
     return JsonResponse(serializer.data, safe=False)
 
+@api_view(['GET', 'DELETE'])
+def scheduled_activity(request, user_id, scheduled_activity_id):
+    if request.method == 'GET':
+        try:
+            queryset = ScheduledActivity.objects.get(id=scheduled_activity_id)
+        except:
+            return HttpResponse('Record not found', status=404)
 
-def scheduled_activity_show(request, user_id, scheduled_activity_id):
-    queryset = ScheduledActivity.objects.get(id=scheduled_activity_id)
-    serializer = ScheduledActivitySerializer(queryset)
-    return JsonResponse(serializer.data)
+        serializer = ScheduledActivitySerializer(queryset)
+        return JsonResponse(serializer.data)
 
+    elif request.method == 'DELETE':
+        try:
+            scheduled_activity = ScheduledActivity.objects.get(id=scheduled_activity_id)
+        except:
+            return HttpResponse('Record not found', status=404)
+
+        try:
+            scheduled_activity.delete()
+            return HttpResponse('Deleted successfully', status=204)
+        except:
+            return HttpResponse('Unable to delete record', status=500)
 
 def user_scheduled_activity_index(request, user_id):
     queryset = User.objects.get(id=user_id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Chore
- [ ] Documentation Update

## Description

Add endpoint for ScheduledActivity which takes DELETE requests to delete that record.

`DELETE /api/v1/users/:user_id/scheduled_activities/:scheduled_activity_id`

will delete that scheduled_activity record. Will raise `404` error if record with that ID is not found, and `500` if server is unable to delete the record.

## Related Issues & Documents

Closes #40 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
